### PR TITLE
Fixed duplicate keys problem by creating an extension to the NameValu…

### DIFF
--- a/src/RA.Tests/MockExecutionContextWithMulitipleQueries.cs
+++ b/src/RA.Tests/MockExecutionContextWithMulitipleQueries.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace RA.Tests
+{
+    [TestFixture]
+    public class MockExecutionContextWithMulitipleQueries
+    {
+        private ExecutionContext _execution;
+        private string _key;
+        private string _val;
+        private string _val2;
+
+        public MockExecutionContextWithMulitipleQueries()
+        {
+            _key = "foo";
+            _val = "bar";
+            _val2 = "baz";
+
+            var _setup = new SetupContext()
+                .Query(_key, _val)
+                .Query(_key, _val2);
+            _execution = new HttpActionContext(_setup)
+                .Get("http://test.com");
+
+        }
+
+        [Test]
+        public void UrlContainsAllQuiries()
+        {
+            var stout = Console.Out;
+            using (StringWriter sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+
+                _execution.Debug();
+                Console.SetOut(stout);
+
+                StringAssert.Contains(string.Format("{0}={1}", _key, _val), sw.ToString());
+                StringAssert.Contains(string.Format("{0}={1}", _key, _val2), sw.ToString());
+            }
+        }
+    }
+}

--- a/src/RA/ExecutionContext.cs
+++ b/src/RA/ExecutionContext.cs
@@ -149,12 +149,9 @@ namespace RA
             var builder = new UriBuilder(_httpActionContext.Url());
             var query = HttpUtility.ParseQueryString(builder.Query);
 
-            foreach (var queryString in _setupContext.Queries())
-            {
-                query.Add(_setupContext.Queries());
-            }
+            query.Add(_setupContext.Queries());
 
-            builder.Query = query.ToString();
+            builder.Query = query.ToQueryString();
             return new Uri(builder.ToString());
         }
 

--- a/src/RA/Extensions/NameValueCollectionExtensions.cs
+++ b/src/RA/Extensions/NameValueCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace RA.Extensions
+{
+    public static class NameValueCollectionExtensions
+    {
+        public static string ToQueryString(this NameValueCollection nvc)
+        {
+            int count = nvc.Count;
+            if (count == 0)
+                return "";
+            StringBuilder sb = new StringBuilder();
+            string[] keys = nvc.AllKeys;
+
+            var items = nvc.AllKeys.SelectMany(nvc.GetValues, (k, v) => new { key = k, value = v });
+            foreach (var item in items)
+                sb.AppendFormat("{0}={1}&", item.key, HttpUtility.UrlEncode(item.value, Encoding.UTF8));
+
+            if (sb.Length > 0)
+                sb.Length--;
+            return sb.ToString();
+        }
+
+
+    }
+}


### PR DESCRIPTION
I built a test case for your change and found it doesn't work as intended. If you pass in two queries of "foo" with values of "bar" and "baz" the ToString that is called on the query NVC will treat this the same as passing in one query with the key "foo" and the value "bar,baz", treating the values as comma deliminated. 

To fix this I've created an extension to the NVC class that essentially overrides the ToString in the HttpUtils class. I've also included the test case I wrote for this so that it can be demonstrated to now be working as intended. 